### PR TITLE
upload avatar #10

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/dao/UserInfDao.java
+++ b/src/main/java/dao/UserInfDao.java
@@ -257,6 +257,21 @@ public boolean insertAddressUser(UserInf userInf){
             }
         }
     }
+// Up load ảnh đại diện
+public boolean updateAvatar(int userID, String imageUrl) {
+    String sql = "UPDATE UserArress SET imageURL = ? WHERE userID = ?";
+    try {
+        PreparedStatement ps = conn.prepareStatement(sql);
+        ps.setString(1, imageUrl);
+        ps.setInt(2, userID);
+
+        int row = ps.executeUpdate();
+        return row > 0; // Trả về true nếu cập nhật thành công
+    } catch (SQLException e) {
+        e.printStackTrace();
+    }
+    return false; // Trả về false nếu có lỗi
+}
 
     public static void main(String[] args) {
         String name  ="%le%";

--- a/src/main/java/object/User.java
+++ b/src/main/java/object/User.java
@@ -1,6 +1,8 @@
 package object;
 
 
+import dao.UserInfDao;
+
 import java.util.Date;
 
 public class User {
@@ -12,6 +14,7 @@ public class User {
     private String role;
     private String malle;
     private String sdt;
+    private String avatar;
 
     // Constructors
     public User(int id, String fullName, String email, String password, String role , String malle, Date date,String sdt) {
@@ -23,6 +26,7 @@ public class User {
         this.malle = malle;
         this.date = date;
         this.sdt = sdt;
+        this.avatar = avatar;
     }
 
     public User(String email, String fullName, int id) {
@@ -70,7 +74,7 @@ public class User {
 
     public void setId(int id) {
         this.id = id;
-    } 
+    }
 
     public String getFullName() {
         return fullName;
@@ -106,10 +110,13 @@ public class User {
     public void setRole(String role){
         this.role = role;
     }
-    public String getRole(){
-        return role;
+    public String getRole(){return role;}
+    public String getAvatar() {return avatar;}
+    public void setAvatar(String avatar) {
+        this.avatar = avatar;
+        UserInfDao userDao = new UserInfDao();
+        userDao.updateAvatar(this.id, avatar);
     }
-
     // toString method
     @Override
     public String toString() {
@@ -119,6 +126,7 @@ public class User {
                 ", email='" + email + '\'' +
                 ", password='" + password + '\'' +
                 ", date=" + date +
+                ", avatar='" + avatar + '\'' +
                 '}';
     }
 }

--- a/src/main/java/servlet/ManageUser/UploadAvatarServlet.java
+++ b/src/main/java/servlet/ManageUser/UploadAvatarServlet.java
@@ -1,0 +1,47 @@
+package servlet.ManageUser;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.MultipartConfig;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.*;
+import object.User;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+@WebServlet("/uploadAvatar")
+@MultipartConfig(
+        fileSizeThreshold = 1024 * 1024,
+        maxFileSize = 5 * 1024 * 1024,
+        maxRequestSize = 10 * 1024 * 1024
+)
+public class UploadAvatarServlet extends HttpServlet {
+    private static final String UPLOAD_DIR = "uploads";
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, IOException {
+        Part filePart = request.getPart("avatar");
+        String fileName = Paths.get(filePart.getSubmittedFileName()).getFileName().toString();
+
+        if (filePart.getSize() > 0) {
+            String uploadPath = getServletContext().getRealPath("") + File.separator + UPLOAD_DIR;
+            File uploadDir = new File(uploadPath);
+            if (!uploadDir.exists()) uploadDir.mkdirs();
+
+            String filePath = uploadPath + File.separator + fileName;
+            filePart.write(filePath);
+
+            String imageUrl = request.getContextPath() + "/" + UPLOAD_DIR + "/" + fileName;
+
+            // Cập nhật đường dẫn ảnh trong session
+            HttpSession session = request.getSession();
+            User user = (User) session.getAttribute("user");
+            user.setAvatar(imageUrl);
+            session.setAttribute("user", user);
+
+            response.getWriter().write("{\"success\": true, \"imageUrl\": \"" + imageUrl + "\"}");
+        } else {
+            response.getWriter().write("{\"success\": false}");
+        }
+    }
+}

--- a/src/main/webapp/index/inforUser.jsp
+++ b/src/main/webapp/index/inforUser.jsp
@@ -68,16 +68,17 @@
         <div class="account-section">
           <form action="http://localhost:8080/WebMyPham__/updateInforUser" method="post" class="form" id="register-form">
           <h2>Thông tin tài khoản</h2>
-          <div class="profile-picture">
-            <div class="profile-picture-left">
-              <img src="https://hasaki.vn/images/graphics/account-full.svg" alt="Tài ảnh của bạn">
-              <a>Tải ảnh của bạn</a>
+            <div class="profile-picture">
+              <div class="profile-picture-left">
+                <img id="avatar-preview" src="${sessionScope.user.avatar != null ? sessionScope.user.avatar : 'https://hasaki.vn/images/graphics/account-full.svg'}" alt="Ảnh đại diện của bạn">
+                <input type="file" id="avatar-upload" name="avatar" accept="image/*">
+              </div>
+              <div class="profile-picture-right">
+                <input type="email" name="email" value="${sessionScope.user.email}" readonly>
+                <input type="text" name="name" value="${sessionScope.user.fullName}">
+              </div>
             </div>
-            <div class="profile-picture-right">
-              <input type="email" name="email" value="${sessionScope.user.email}" readonly>
-              <input type="text" name="name" value="${sessionScope.user.fullName}">
-            </div>
-          </div>
+            <button type="button" onclick="uploadAvatar()">Cập nhật ảnh đại diện</button>
 
 
           <div class="gender-selection">
@@ -140,7 +141,7 @@
     <script src="../js/updateUserMain.js"></script>
     <script src="../js/main.js"></script>
 
-
+    <script src="../js/uploadAvatar.js"></script>
 
 
 

--- a/src/main/webapp/js/uploadAvatar.js
+++ b/src/main/webapp/js/uploadAvatar.js
@@ -1,0 +1,37 @@
+ document.getElementById("avatar-upload").addEventListener("change", function(event) {
+    let file = event.target.files[0];
+    if (file) {
+    let reader = new FileReader();
+    reader.onload = function(e) {
+    document.getElementById("avatar-preview").src = e.target.result;
+};
+    reader.readAsDataURL(file);
+}
+});
+
+    function uploadAvatar() {
+    let formData = new FormData();
+    let fileInput = document.getElementById("avatar-upload");
+
+    if (fileInput.files.length === 0) {
+    alert("Vui lòng chọn ảnh!");
+    return;
+}
+
+    formData.append("avatar", fileInput.files[0]);
+
+    fetch("http://localhost:8080/WebMyPham__/uploadAvatar", {
+    method: "POST",
+    body: formData
+})
+    .then(response => response.json())
+    .then(data => {
+    if (data.success) {
+    document.getElementById("avatar-preview").src = data.imageUrl;
+    alert("Cập nhật ảnh đại diện thành công!");
+} else {
+    alert("Upload thất bại!");
+}
+})
+    .catch(error => console.error("Lỗi:", error));
+}


### PR DESCRIPTION
- Chức năng cho phép người dùng thay đổi ảnh đại diện bằng cách upload file từ máy tính.
- Ảnh sau khi tải lên sẽ được lưu vào thư mục uploads/avatars (hoặc lưu vào database nếu dùng cloud storage).
- Kiểm tra định dạng ảnh trước khi lưu để tránh lỗi.
- lưu ảnh vào thư mục server hoặc cloud storage.
Cập nhật đường dẫn ảnh trong database.
- Trả về phản hồi JSON cho frontend.